### PR TITLE
Add certificate.html to show certificate

### DIFF
--- a/credentials/apps/credentials_theme_openedx/templates/openedx/credentials/programs/xseries/certificate.html
+++ b/credentials/apps/credentials_theme_openedx/templates/openedx/credentials/programs/xseries/certificate.html
@@ -1,0 +1,21 @@
+{% extends 'credentials/programs/base.html' %}
+{% load i18n_assets %}
+{% load i18n %}
+{% load staticfiles %}
+{% block accomplishment_summary %}
+  {% trans "successfully completed all courses and received passing grades for a Professional Certificate in" as tmsg %} {{ tmsg | force_escape }}
+{% endblock %}
+{% block accomplishment_stamp_title %}
+  {% trans "Professional Certificate" as tmsg %}{{ tmsg | force_escape }}
+{% endblock %}
+{% block background_watermark %}
+  {% include 'openedx/images/example-watermark.svg' %}
+{% endblock %}
+{% block background_logo %}
+    {% include 'openedx/images/example-logo-en.svg'|translate_file_path %}
+{% endblock %}
+{% block platform_logo %}
+  <a class="logo" href="{{ site.siteconfiguration.lms_url_root }}">
+    <img src="{% static 'images/openedx-logo.png' %}">
+  </a>
+{% endblock %}


### PR DESCRIPTION
**Description:** Added certificate.html to show the certificate. This is required as edX allows us to customize and our current theme needs that to show the certificate. Ideally, this would be present in our themes too with header & footer files too.

**Jira:** https://edlyio.atlassian.net/browse/EDLY-1283

<img width="1437" alt="Screenshot 2020-09-10 at 5 17 14 PM" src="https://user-images.githubusercontent.com/15142776/92729311-95f3ad80-f38b-11ea-991b-cf48993253d6.png">
<img width="1437" alt="Screenshot 2020-09-10 at 5 25 28 PM" src="https://user-images.githubusercontent.com/15142776/92729322-99873480-f38b-11ea-80f1-c6c299cd0944.png">
