### PR TITLE
 EDLY-2025 Set order of signatories while returning response

### DIFF
--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/views/program_certificate_configuration.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/views/program_certificate_configuration.py
@@ -1,11 +1,12 @@
 """
 Views for Edly Program Certificate Configuration API.
 """
+from django.db.models import Prefetch
 from rest_framework import status, viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from credentials.apps.credentials.models import ProgramCertificate
+from credentials.apps.credentials.models import ProgramCertificate, Signatory
 from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.permissions import CanAccessCurrentSite
 from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.serializers import (
     ProgramCertificateConfigurationSerializer
@@ -20,7 +21,11 @@ class ProgramCertificateConfigurationViewSet(viewsets.ModelViewSet):
     lookup_value_regex = '[0-9a-f-]+'
     permission_classes = (IsAuthenticated, CanAccessCurrentSite)
     serializer_class = ProgramCertificateConfigurationSerializer
-    queryset = ProgramCertificate.objects.all()
+
+    def get_queryset(self):
+        return ProgramCertificate.objects.all().prefetch_related(
+            Prefetch('signatories', queryset=Signatory.objects.all().order_by('-id'))
+        )
 
     def update(self, request, *args, **kwargs):
         """


### PR DESCRIPTION
**Description:** We need to explicitly order signatories because we are setting signatories in WordPress by index. [Relavant line](https://github.com/edly-io/edly-wp-plugin/pull/317/files#diff-8606f04fe065eca69a700910366f5641309cc8edab8bc3979990bcca9640c0f5R193)
**Related PR:** https://github.com/edly-io/edly-wp-plugin/pull/317
