### PR TITLE
EDLY-2904 Add credentials site creation API

### DIFF
--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/permissions.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/permissions.py
@@ -5,6 +5,7 @@ import logging
 
 from rest_framework import permissions
 
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.v1.constants import EDLY_PANEL_WORKER_USER
 from credentials.apps.edx_credentials_extensions.edly_credentials_app.utils import user_has_edx_organization_access
 
 logger = logging.getLogger(__name__)
@@ -23,3 +24,16 @@ class CanAccessCurrentSite(permissions.BasePermission):
             return True
 
         return False
+
+
+class CanAccessSiteCreation(permissions.BasePermission):
+    """
+    Checks if a user has the access to create and update methods for sites.
+    """
+
+    def has_permission(self, request, view):
+        """
+        Checks for user's permission for current site.
+        """
+        logger.info('User {user} is trying to access site creation API'.format(user=request.user.username))
+        return request.user.is_staff or request.user.username == EDLY_PANEL_WORKER_USER

--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/constants.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/constants.py
@@ -1,0 +1,22 @@
+"""
+Constants for Edly Credentials API.
+"""
+from django.utils.translation import ugettext as _
+
+ERROR_MESSAGES = {
+    'CLIENT_SITES_SETUP_SUCCESS': _('Client sites setup successful.'),
+    'CLIENT_SITES_SETUP_FAILURE': _('Client sites setup failed.'),
+}
+
+CLIENT_SITE_SETUP_FIELDS = [
+    'lms_site',
+    'credentials_site',
+    'wordpress_site',
+    'edly_slug',
+    'platform_name',
+    'discovery_site',
+    'theme_dir_name',
+    'oauth_clients'
+]
+
+EDLY_PANEL_WORKER_USER = 'edly_panel_worker'

--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/urls.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/urls.py
@@ -1,9 +1,15 @@
+from django.conf.urls import url
 from rest_framework import routers
 
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.v1.views.edly_sites import EdlySiteViewSet
 from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.v1.views.program_certificate_configuration import ProgramCertificateConfigurationViewSet
 
 
 router = routers.SimpleRouter()
 router.register(r'program-certificate-configuration', ProgramCertificateConfigurationViewSet, basename='program-certificate-configuration')
 
-urlpatterns = router.urls
+urlpatterns = [
+    url(r'^edly_sites/', EdlySiteViewSet.as_view(), name='edly_sites'),
+]
+
+urlpatterns += router.urls

--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/views/edly_sites.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/api/v1/views/edly_sites.py
@@ -1,0 +1,80 @@
+"""
+Views for Edly Site Creation API.
+"""
+from django.contrib.sites.models import Site
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from credentials.apps.core.models import SiteConfiguration
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.permissions import CanAccessSiteCreation
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.v1.constants import ERROR_MESSAGES
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.helpers import (
+    get_credentials_site_configuration,
+    validate_site_configurations,
+)
+
+
+class EdlySiteViewSet(APIView):
+    """
+    Creates credentials site and it's site configuration.
+    """
+    permission_classes = [IsAuthenticated, CanAccessSiteCreation]
+
+    def post(self, request):
+        """
+        POST /api/edly_api/v1/edly_sites.
+        """
+        validations_messages = validate_site_configurations(request.data)
+        if len(validations_messages) > 0:
+            return Response(validations_messages, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            self.process_client_sites_setup()
+            return Response(
+                {'success': ERROR_MESSAGES.get('CLIENT_SITES_SETUP_SUCCESS')},
+                status=status.HTTP_200_OK
+            )
+        except TypeError:
+            return Response(
+                {'error': ERROR_MESSAGES.get('CLIENT_SITES_SETUP_FAILURE')},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+    def process_client_sites_setup(self):
+        """
+        Process client sites setup and update configurations.
+        """
+        edly_slug = self.request.data.get('edly_slug', '')
+        credentials_base = self.request.data.get('credentials_site', '')
+        theme_dir_name = self.request.data.get('theme_dir_name', 'openedx')
+        lms_url_root = '{protocol}://{lms_url_root}'.format(
+            protocol=self.request.data.get('protocol', 'https'),
+            lms_url_root=self.request.data.get('lms_site', '')
+        )
+        catalog_api_url = '{protocol}://{discovery_site}/api/v1/'.format(
+            protocol=self.request.data.get('protocol', 'https'),
+            discovery_site=self.request.data.get('discovery_site', '')
+        )
+        wordpress_site = '{protocol}://{wordpress_site}'.format(
+            protocol=self.request.data.get('protocol', 'https'),
+            wordpress_site=self.request.data.get('wordpress_site', '')
+        )
+        credentials_site, __ = Site.objects.update_or_create(domain=credentials_base, defaults=dict(name=credentials_base))
+        credentials_site_config, __ = SiteConfiguration.objects.update_or_create(
+            site=credentials_site,
+            defaults=dict(
+                edx_org_short_name=edly_slug,
+                platform_name=self.request.data.get('platform_name', ''),
+                company_name=self.request.data.get('platform_name', ''),
+                theme_name=theme_dir_name,
+                lms_url_root=lms_url_root,
+                catalog_api_url=catalog_api_url,
+                tos_url='{lms_url_root}/tos'.format(lms_url_root=lms_url_root),
+                privacy_policy_url='{lms_url_root}/privacy'.format(lms_url_root=lms_url_root),
+                homepage_url=wordpress_site,
+                certificate_help_url='{wordpress_site}/contact-us'.format(wordpress_site=wordpress_site),
+                edly_client_branding_and_django_settings=get_credentials_site_configuration(self.request.data),
+            )
+        )

--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/helpers.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/helpers.py
@@ -1,0 +1,60 @@
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.api.v1.constants import CLIENT_SITE_SETUP_FIELDS
+
+
+def validate_site_configurations(request_data):
+    """
+    Identify missing required fields for client's site setup.
+
+    Arguments:
+        request_data (dict): Request data passed for site setup
+
+    Returns:
+        validation_messages (dict): Missing fields information
+    """
+
+    validation_messages = {}
+
+    for field in CLIENT_SITE_SETUP_FIELDS:
+        if not request_data.get(field, None):
+            validation_messages[field] = '{0} is Missing'.format(field.replace('_', ' ').title())
+
+    return validation_messages
+
+
+def get_credentials_site_configuration(request_data):
+    """
+    Prepare Credentials Site Configurations for Client based on Request Data.
+
+    Arguments:
+        request_data (dict): Request data passed for site setup
+
+    Returns:
+        (dict): Credentials Site Configuration
+    """
+    protocol = request_data.get('protocol', 'https')
+    lms_site = request_data.get('lms_site', '')
+    lms_site_with_protocol = '{protocol}://{lms_root_domain}'.format(
+        protocol=protocol,
+        lms_root_domain=lms_site,
+    )
+    oauth2_clients = request_data.get('oauth_clients', {})
+    credentials_sso_values = oauth2_clients.get('credentials-sso', {})
+    credentials_backend_values = oauth2_clients.get('credentials-backend', {})
+
+    return {
+        'DJANGO_SETTINGS_OVERRIDE': {
+            'SOCIAL_AUTH_EDX_OAUTH2_KEY': credentials_sso_values.get('id', ''),
+            'SOCIAL_AUTH_EDX_OAUTH2_SECRET': credentials_sso_values.get('secret', ''),
+            'SOCIAL_AUTH_EDX_OAUTH2_ISSUER': lms_site_with_protocol,
+            'SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT': lms_site_with_protocol,
+            'SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT': lms_site_with_protocol,
+            'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': '{lms_site_with_protocol}/logout'.format(
+                lms_site_with_protocol=lms_site_with_protocol
+            ),
+            'BACKEND_SERVICE_EDX_OAUTH2_KEY': credentials_backend_values.get('id', ''),
+            'BACKEND_SERVICE_EDX_OAUTH2_SECRET': credentials_backend_values.get('secret', ''),
+            'BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL': '{lms_site_with_protocol}/oauth2'.format(
+                lms_site_with_protocol=lms_site_with_protocol
+            ),
+        }
+    }

--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/tests/test_helpers.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/tests/test_helpers.py
@@ -1,0 +1,87 @@
+import pytest
+from django.test import RequestFactory, TestCase
+
+from credentials.apps.core.tests.factories import SiteFactory
+from credentials.apps.edx_credentials_extensions.edly_credentials_app.helpers import (
+    get_credentials_site_configuration,
+    validate_site_configurations,
+)
+
+
+@pytest.mark.django_db
+class EdlyAppHelperMethodsTests(TestCase):
+    """
+    Unit tests for helper methods.
+    """
+
+    def setUp(self):
+        super(EdlyAppHelperMethodsTests, self).setUp()
+        self.request = RequestFactory().get('/')
+        self.request.site = SiteFactory()
+        self.request_data = dict(
+            lms_site='example.lms',
+            credentials_site='example.credentials',
+            wordpress_site='example.wordpress',
+            edly_slug='edx',
+            platform_name='Edly',
+            discovery_site='example.discovery',
+            theme_dir_name='openedx',
+            oauth_clients={
+                'credentials-sso': {
+                    'id': 'credentials-sso-key',
+                    'secret': 'credentials-sso-secret'
+                },
+                'credentials-backend': {
+                    'id': 'credentials-backend-key',
+                    'secret': 'credentials-backend-secret'
+                }
+            },
+        )
+
+    def test_validate_site_configurations(self):
+        """
+        Test that required site creation data is present in request data.
+        """
+        lms_site = self.request_data.pop('lms_site')
+        validation_messages = validate_site_configurations(self.request_data)
+        expected_message = 'Lms Site is Missing'
+        assert validation_messages.get('lms_site') == expected_message
+
+        self.request_data['lms_site'] = lms_site
+        validation_messages = validate_site_configurations(self.request_data)
+        assert not validation_messages
+
+    def test_get_credentials_site_configuration(self):
+        """
+        Test that correct credentials site configuration data is returned using the request data.
+        """
+        protocol = self.request_data.get('protocol', 'https')
+        lms_site = self.request_data.get('lms_site', '')
+        lms_site_with_protocol = '{protocol}://{lms_root_domain}'.format(
+            protocol=protocol,
+            lms_root_domain=lms_site,
+        )
+        oauth2_clients = self.request_data.get('oauth_clients', {})
+        credentials_sso_values = oauth2_clients.get('credentials-sso', {})
+        credentials_backend_values = oauth2_clients.get('credentials-backend', {})
+        expected_site_configuration = {
+            'DJANGO_SETTINGS_OVERRIDE': {
+                'SOCIAL_AUTH_EDX_OAUTH2_KEY': credentials_sso_values.get('id', ''),
+                'SOCIAL_AUTH_EDX_OAUTH2_SECRET': credentials_sso_values.get('secret', ''),
+                'SOCIAL_AUTH_EDX_OAUTH2_ISSUER': lms_site_with_protocol,
+                'SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT': lms_site_with_protocol,
+                'SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT': lms_site_with_protocol,
+                'SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL': '{lms_site_with_protocol}/logout'.format(
+                    lms_site_with_protocol=lms_site_with_protocol
+                ),
+                'BACKEND_SERVICE_EDX_OAUTH2_KEY': credentials_backend_values.get('id', ''),
+                'BACKEND_SERVICE_EDX_OAUTH2_SECRET': credentials_backend_values.get('secret', ''),
+                'BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL': '{lms_site_with_protocol}/oauth2'.format(
+                    lms_site_with_protocol=lms_site_with_protocol
+                ),
+            }
+        }
+
+        credentials_site_configuration = get_credentials_site_configuration(self.request_data)
+        for key, value in credentials_site_configuration.items():
+            assert expected_site_configuration[key] == value

--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -52,7 +52,7 @@ urlpatterns = oauth2_urlpatterns + [
 
 # Edly Urls
 urlpatterns += [
-    url(r'^edly-api/', include(('credentials.apps.edx_credentials_extensions.edly_credentials_app.urls', 'edly_credentials_app'), namespace='edly_api')),
+    url(r'^edly_api/', include(('credentials.apps.edx_credentials_extensions.edly_credentials_app.urls', 'edly_credentials_app'), namespace='edly_api')),
 ]
 
 handler500 = 'credentials.apps.core.views.render_500'


### PR DESCRIPTION
**Description:** Added credentials site creation API.

**JIRA:** https://edlyio.atlassian.net/browse/EDLY-2904

**Related PR:** https://github.com/edly-io/edly-wp-plugin/pull/362

```
POST /edly_api/v1/edly_sites/
```
Sample payload:
```
{
    "lms_site": "red.edx.devstack.lms:18000",
    "credentials_site": "red.edx.devstack.lms:18150",
    "wordpress_site": "wordpress.red.edx.devstack.lms",
    "edly_slug": "red",
    "platform_name": "Red",
    "catalog_api_url": "red.edx.devstack.lms:18381/api/v1/",
    "theme_dir_name": "openedx",
    "oauth_clients": {
        "credentials-sso":{
            "id": "red-credentials-sso-key",
            "secret": "red-credentials-sso-secret"
        },
        "credentials-backend":{
            "id": "red-credentials-backend-key",
            "secret": "red-credentials-backend-secret"
        }
    }
}
```
