### PR TITLE
Add language selection field in the sites creation automation form

### DIFF
--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/helpers.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/helpers.py
@@ -40,6 +40,7 @@ def get_credentials_site_configuration(request_data):
     oauth2_clients = request_data.get('oauth2_clients', {})
     credentials_sso_values = oauth2_clients.get('credentials-sso', {})
     credentials_backend_values = oauth2_clients.get('credentials-backend', {})
+    language_code = request_data.get('language_code', 'en')
 
     return {
         'DJANGO_SETTINGS_OVERRIDE': {
@@ -56,6 +57,6 @@ def get_credentials_site_configuration(request_data):
             'BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL': '{lms_site_with_protocol}/oauth2'.format(
                 lms_site_with_protocol=lms_site_with_protocol
             ),
-            'LANGUAGE_CODE': request_data.get('language_code', 'en'),
+            'LANGUAGE_CODE': language_code,
         }
     }

--- a/credentials/apps/edx_credentials_extensions/edly_credentials_app/helpers.py
+++ b/credentials/apps/edx_credentials_extensions/edly_credentials_app/helpers.py
@@ -56,5 +56,6 @@ def get_credentials_site_configuration(request_data):
             'BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL': '{lms_site_with_protocol}/oauth2'.format(
                 lms_site_with_protocol=lms_site_with_protocol
             ),
+            'LANGUAGE_CODE': request_data.get('language_code', 'en'),
         }
     }


### PR DESCRIPTION
Description: We should be able to set the primary language with the sites creation automation form

JIRA:
https://edlyio.atlassian.net/browse/EDLY-3577

Testing instructions:
     1. Open the Client site automation form, fill the form and submit it successfully.
     2. Open the sites you have created for the client (wordpress, lms, studio, ecommerce, credentials)
     3. All of the sites should have the primary language set to the language code provided in client automation form.
     4. If not the same language, then test failed.

Make sure that the following steps are done before rebasing/merging

  - [ ] Request a review if desired
  - [ ] Squash/Fixup your branch to one commit
  - Config/Dependency Changes (e.g. config files, scripts that are used for provisioning etc.)
    - [ ] Make sure you have updated [edx/configuration](https://github.com/edx/configuration) and [edx/devstack](https://github.com/edx/devstack) if necessary
    - [ ] Make sure the change builds successfully in a sandbox
  - UI Changes 
    - [ ] Consider other browsers (e.g. Firefox)
    - [ ] Check mobile view
    - [ ] Consider accessibility (e.g. Run aXe on the page)
