### PR TITLE
Retries for Access Token Request

### DIFF
--- a/credentials/apps/core/models.py
+++ b/credentials/apps/core/models.py
@@ -177,7 +177,7 @@ class SiteConfiguration(models.Model):
     @property
     def user_api_url(self):
         return '{}/api/user/v1/'.format(self.lms_url_root.strip('/'))
-    
+
     @property
     def access_token(self):
         """ Returns an access token for this site's service user.


### PR DESCRIPTION
Added retries to avoid 403 response because lms access token has rate limit of 120/m.
https://edlyio.atlassian.net/browse/EDLY-6810
