### PR TITLE
fix: remove course certificate filter from user program data retrieval

### DIFF
--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -60,6 +60,7 @@ def filter_visible(qs: "QuerySet") -> "QuerySet":
     Filters a UserCredentials queryset by excluding credentials that aren't
     supposed to be visible yet.
     """
+    # EDLYCUSTOM: we do not save course cert in credentials service, so removing this filter for now
     visible_course_certs = _filter_visible_course_certificates(qs)
     visible_program_certs = _filter_visible_program_certificates(qs.filter(program_credentials__isnull=False))
     visible_certs = visible_course_certs | visible_program_certs

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -171,7 +171,8 @@ def get_user_program_data(
         allowed_statuses.append(ProgramStatus.RETIRED.value)
 
     # Get a list of programs
-    programs = get_filtered_programs(request_site, allowed_statuses, **course_filters)
+    # EDLYCUSTOM: we do not save course cert in credentials service, so removing this filter for now
+    programs = get_filtered_programs(request_site, allowed_statuses)
 
     # Get the completed programs and a UUID set using the program_credentials
     program_credential_ids = [program_credential.credential_id for program_credential in program_credentials]


### PR DESCRIPTION
## Description
Updated the filtering logic in the user program data retrieval function to remove the course certificate filter, as course certificates are not saved in the credentials service. This change is intended to streamline the data retrieval process.

